### PR TITLE
Update dummy functions to match signature

### DIFF
--- a/src/dummy.c
+++ b/src/dummy.c
@@ -2,10 +2,11 @@
    (this package uses NAMESPACE C-level symbol registration
    but the checks don't get that) */
 
-extern void R_registerRoutines(void);
-extern void R_useDynamicSymbols(void);
+#include <stdlib.h>
+#include <R_ext/Rdynload.h>
+#include <Rinternals.h>
 
 void dummy(void) {
-    R_registerRoutines();
-    R_useDynamicSymbols();
+    R_registerRoutines(NULL, NULL, NULL, NULL, NULL);
+    R_useDynamicSymbols(NULL, TRUE);
 }


### PR DESCRIPTION
I know these are dummy functions but some runtimes still enforce that the signature matches with the one in base R. So why not use the real headers.